### PR TITLE
Port to makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,9 @@ CFLAGS += -g
 
 # valgrind-compatibile builds are enabled by uncommenting lines in valgind.mk
 
+# Shards of explicit template instantiation files
+NUM_SERIALIZER_FILES ?= 8
+
 # Define the TLS compilation and link variables
 ifdef TLS_DISABLED
 CFLAGS += -DTLS_DISABLED

--- a/build/vcxproj.mk
+++ b/build/vcxproj.mk
@@ -51,7 +51,17 @@ VPATH += $(addprefix :,$(patsubst -L%,%,$(filter -L%,$(GENNAME()_LDFLAGS))))
 
 IGNORE := $(shell echo $(VPATH))
 
+GENNAME()_SERIALIZERS := $(patsubst %,$(OBJDIR)/GENDIR/SerializeImpl%.cpp,$(shell seq 0 $$((${NUM_SERIALIZER_FILES}-1))))
+${GENNAME()_SERIALIZERS}: $(OBJDIR)/GENDIR/make_serializers.timestamp
+
+$(OBJDIR)/GENDIR/make_serializers.timestamp: cmake/templates.json cmake/generate_templates.py $(ALL_MAKEFILES)
+	@echo "Instantiating  GENNAME()"
+	@mkdir -p $(OBJDIR)/GENDIR && \
+	python cmake/generate_templates.py -N $$((${NUM_SERIALIZER_FILES}-1)) -t GENDIR -o $(OBJDIR)/GENDIR/SerializeImpl cmake/templates.json && \
+	touch $@
+
 GENNAME()_OBJECTS := $(addprefix $(OBJDIR)/,$(filter-out $(OBJDIR)/%,$(GENNAME()_BUILD_SOURCES:=.o))) $(filter $(OBJDIR)/%,$(GENNAME()_BUILD_SOURCES:=.o))
+GENNAME()_OBJECTS += ${GENNAME()_SERIALIZERS:.cpp=.cpp.o}
 GENNAME()_DEPS := $(addprefix $(DEPSDIR)/,$(GENNAME()_BUILD_SOURCES:=.d))
 
 .PHONY: GENNAME()_clean GENNAME

--- a/cmake/generate_templates.py
+++ b/cmake/generate_templates.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import json
-import argparse
+import optparse
 import filecmp
 import os
 import shutil
@@ -11,34 +11,31 @@ class InternalError(Exception):
     pass
 
 
-class TemplateGenerator:
+class TemplateGenerator(object):
     def __init__(self, args):
         self.targetName = args.target
         self.numFiles = args.num_files
         self.fileName = args.out
         with open(args.file, 'r') as f:
             self.descr = json.load(f)
-        if args.target not in self.descr:
-            print('ERROR: undefined target {}'.format(args.target))
-            raise InternalError
 
     def generate(self):
-        target = self.descr[self.targetName]
+        target = self.descr.get(self.targetName, {})
         dependencies = []
         for dep in target['dependencies'] if 'dependencies' in target else []:
             if dep not in self.descr:
-                print("ERROR: {} was declared as dependency of {} but does not exist".format(dep, self.targetName))
+                print("ERROR: %s was declared as dependency of %s but does not exist"%(dep, self.targetName))
                 raise InternalError
             dependencies.append((dep, self.descr[dep]))
         for i in range(0, self.numFiles):
-            outFile = "{}{}.cpp".format(self.fileName, i)
-            tmpFile = "{}.tmp".format(outFile)
+            outFile = "%s%d.cpp"%(self.fileName, i)
+            tmpFile = "%s.tmp"%(outFile,)
             with open(tmpFile, 'w') as f:
                 f.write('// This file was generated - DO NOT CHANGE\n\n')
                 for include in target["includes"] if 'includes' in target else []:
-                    f.write('#include "{}"\n'.format(include))
+                    f.write('#include "%s"\n'%(include,))
                 for include in target["sysincludes"] if 'sysincludes' in target else []:
-                    f.write('#include <{}>\n'.format(include))
+                    f.write('#include <%s>\n'%(include,))
                 j = 0
                 f.write('\n\n\n')
                 templates = target['templates'] if 'templates' in target else []
@@ -47,10 +44,10 @@ class TemplateGenerator:
                     for dep in dependencies:
                         ts = dep[1]['templates'] if 'templates' in dep[1] else []
                         if template in ts:
-                            print("ERROR: {} is also defined in {} which is a dependency".format(template, dep[0]))
+                            print("ERROR: %s is also defined in %s which is a dependency"%(template, dep[0]))
                             raise InternalError
                     if j % self.numFiles == i:
-                        f.write('template struct {};\n'.format(template))
+                        f.write('template struct %s;\n'%(template,))
                     j += 1
             # Compiling these files will be quite expensive. So we make sure to only
             # write them if they have changed
@@ -58,11 +55,11 @@ class TemplateGenerator:
                 shutil.copyfile(tmpFile, outFile)
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description="Generate explicit template specification")
-    parser.add_argument('file', type=str, help='The json file with the definitions')
-    parser.add_argument('-N', '--num-files', type=int, default=8)
-    parser.add_argument('-o', '--out', type=str, default="SerializeImpl")
-    parser.add_argument('-t', '--target', type=str, required=True)
-    args = parser.parse_args()
-    generator = TemplateGenerator(args)
+    parser = optparse.OptionParser(description="Generate explicit template specification")
+    parser.add_option('-N', '--num-files', type=int, default=8)
+    parser.add_option('-o', '--out', type=str, default="SerializeImpl")
+    parser.add_option('-t', '--target', type=str)
+    options, args = parser.parse_args()
+    options.file = args[0]
+    generator = TemplateGenerator(options)
     generator.generate()


### PR DESCRIPTION
* Docker image only has python 2.6
* It's far easier to just generate empty files for projects that don't have templates to instantiate.
* Generating multiple files from one command is hard in GNU Make

Some of these shards still take a really long time to compile.  Shard 1 of fdbserver took 5GB RAM and 3min when compiled locally.  I didn't compare a before and after timing yet, but `make packages` works for me, and CI will complain if I missed something.